### PR TITLE
Refine aggregation methods and remove underscore prefix

### DIFF
--- a/library/Xi/Collections/Collection.php
+++ b/library/Xi/Collections/Collection.php
@@ -1,5 +1,10 @@
 <?php
+
 namespace Xi\Collections;
+
+use Traversable;
+use Closure;
+use UnderflowException;
 
 /**
  * Extends the Enumerable collection operations to a superset that includes
@@ -223,28 +228,32 @@ interface Collection extends Enumerable
     /**
      * Returns the minimum value in the collection.
      *
-     * @return mixed|null
+     * @return mixed
+     * @throws UnderflowException If the collection is empty.
      */
     public function min();
 
     /**
      * Returns the maximum value in the collection.
      *
-     * @return mixed|null
+     * @return mixed
+     * @throws UnderflowException If the collection is empty.
      */
     public function max();
 
     /**
-     * Returns the sum of values in the collection.
+     * Returns the sum of values in the collection. The sum of an empty
+     * collection is 0.
      *
-     * @return mixed|null
+     * @return mixed
      */
     public function sum();
 
     /**
-     * Returns the product of values in the collection.
+     * Returns the product of values in the collection. The product of an empty
+     * collection is 1.
      *
-     * @return mixed|null
+     * @return mixed
      */
     public function product();
 

--- a/library/Xi/Collections/Collection/AbstractCollection.php
+++ b/library/Xi/Collections/Collection/AbstractCollection.php
@@ -1,9 +1,11 @@
 <?php
+
 namespace Xi\Collections\Collection;
 
-use Xi\Collections\Collection,
-    Xi\Collections\Util\Functions,
-    Xi\Collections\Enumerable\AbstractEnumerable;
+use Xi\Collections\Collection;
+use Xi\Collections\Util\Functions;
+use Xi\Collections\Enumerable\AbstractEnumerable;
+use UnderflowException;
 
 /**
  * Provides a trivial implementation of a Collection
@@ -204,6 +206,12 @@ abstract class AbstractCollection extends AbstractEnumerable implements Collecti
      */
     public function min()
     {
+        if ($this->isEmpty()) {
+            throw new UnderflowException(
+                'Can not get a minimum value on an empty collection.'
+            );
+        }
+
         $min = null;
 
         foreach ($this as $value) {
@@ -220,6 +228,12 @@ abstract class AbstractCollection extends AbstractEnumerable implements Collecti
      */
     public function max()
     {
+        if ($this->isEmpty()) {
+            throw new UnderflowException(
+                'Can not get a maximum value on an empty collection.'
+            );
+        }
+
         $max = null;
 
         foreach ($this as $value) {
@@ -236,7 +250,7 @@ abstract class AbstractCollection extends AbstractEnumerable implements Collecti
      */
     public function sum()
     {
-        $sum = null;
+        $sum = 0;
 
         foreach ($this as $value) {
             $sum += $value;
@@ -250,14 +264,10 @@ abstract class AbstractCollection extends AbstractEnumerable implements Collecti
      */
     public function product()
     {
-        $product = null;
+        $product = 1;
 
         foreach ($this as $value) {
-            if ($product === null) {
-                $product = $value;
-            } else {
-                $product *= $value;
-            }
+            $product *= $value;
         }
 
         return $product;

--- a/library/Xi/Collections/Collection/ArrayCollection.php
+++ b/library/Xi/Collections/Collection/ArrayCollection.php
@@ -46,7 +46,7 @@ class ArrayCollection extends ArrayEnumerable implements Collection
     {
         $result = array();
         if ($number > 0) {
-            $result = array_slice($this->_elements, 0, $number, true);
+            $result = array_slice($this->elements, 0, $number, true);
         }
         return static::create($result);
     }
@@ -56,16 +56,16 @@ class ArrayCollection extends ArrayEnumerable implements Collection
      */
     public function rest()
     {
-        return static::create(array_slice($this->_elements, 1, null, true));
+        return static::create(array_slice($this->elements, 1, null, true));
     }
 
     public function filter($callback = null)
     {
         // Passing null to array_filter results in error, but omitting the second argument is ok.
         $result = (null === $callback)
-            ? array_filter($this->_elements)
+            ? array_filter($this->elements)
             // array_filter only provides values; adding keys manually
-            : array_filter($this->_elements, $this->addKeyArgument($callback));
+            : array_filter($this->elements, $this->addKeyArgument($callback));
         return static::create($result);
     }
 
@@ -103,7 +103,7 @@ class ArrayCollection extends ArrayEnumerable implements Collection
     {
         // Providing keys to the callback manually, because index associations
         // are not maintained when array_map is called with multiple arrays.
-        return static::create(array_map($this->addKeyArgument($callback), $this->_elements));
+        return static::create(array_map($this->addKeyArgument($callback), $this->elements));
     }
     
     /**
@@ -122,7 +122,7 @@ class ArrayCollection extends ArrayEnumerable implements Collection
      */
     private function addKeyArgument($callback)
     {
-        $values = $this->_elements;
+        $values = $this->elements;
         return function($value) use($callback, $values) {
             list($key) = each($values);
             return $callback($value, $key);
@@ -131,24 +131,24 @@ class ArrayCollection extends ArrayEnumerable implements Collection
 
     public function concatenate($other)
     {
-        $left = array_values($this->_elements);
+        $left = array_values($this->elements);
         $right = array_values($other->toArray());
         return static::create(array_merge($left, $right));
     }
 
     public function union($other)
     {
-        return static::create($other->toArray() + $this->_elements);
+        return static::create($other->toArray() + $this->elements);
     }
 
     public function values()
     {
-        return static::create(array_values($this->_elements));
+        return static::create(array_values($this->elements));
     }
 
     public function keys()
     {
-        return static::create(array_keys($this->_elements));
+        return static::create(array_keys($this->elements));
     }
 
     public function flatMap($callback)
@@ -185,7 +185,7 @@ class ArrayCollection extends ArrayEnumerable implements Collection
     {
         if (false === $strict) {
             // array_unique can't check for strict uniqueness
-            return static::create(array_unique($this->_elements, SORT_REGULAR));
+            return static::create(array_unique($this->elements, SORT_REGULAR));
         }
         return $this->apply(Functions::unique($strict));
     }
@@ -205,7 +205,7 @@ class ArrayCollection extends ArrayEnumerable implements Collection
      */
     public function reverse()
     {
-        return static::create(array_reverse($this->_elements));
+        return static::create(array_reverse($this->elements));
     }
 
     /**
@@ -214,7 +214,7 @@ class ArrayCollection extends ArrayEnumerable implements Collection
      */
     public function merge(Collection $other)
     {
-        return static::create(array_merge($this->_elements, $other->toArray()));
+        return static::create(array_merge($this->elements, $other->toArray()));
     }
 
     /**
@@ -244,7 +244,7 @@ class ArrayCollection extends ArrayEnumerable implements Collection
             );
         }
 
-        return min($this->_elements);
+        return min($this->elements);
     }
 
     /**
@@ -258,7 +258,7 @@ class ArrayCollection extends ArrayEnumerable implements Collection
             );
         }
 
-        return max($this->_elements);
+        return max($this->elements);
     }
 
     /**
@@ -266,7 +266,7 @@ class ArrayCollection extends ArrayEnumerable implements Collection
      */
     public function sum()
     {
-        return $this->isEmpty() ? 0 : array_sum($this->_elements);
+        return $this->isEmpty() ? 0 : array_sum($this->elements);
     }
 
     /**
@@ -274,7 +274,7 @@ class ArrayCollection extends ArrayEnumerable implements Collection
      */
     public function product()
     {
-        return $this->isEmpty() ? 1 : array_product($this->_elements);
+        return $this->isEmpty() ? 1 : array_product($this->elements);
     }
 
     /**

--- a/library/Xi/Collections/Collection/ArrayCollection.php
+++ b/library/Xi/Collections/Collection/ArrayCollection.php
@@ -1,9 +1,11 @@
 <?php
+
 namespace Xi\Collections\Collection;
 
-use Xi\Collections\Collection,
-    Xi\Collections\Util\Functions,
-    Xi\Collections\Enumerable\ArrayEnumerable;
+use Xi\Collections\Collection;
+use Xi\Collections\Util\Functions;
+use Xi\Collections\Enumerable\ArrayEnumerable;
+use UnderflowException;
 
 /**
  * Implements the Collection operations with native array functions wherever
@@ -236,7 +238,13 @@ class ArrayCollection extends ArrayEnumerable implements Collection
      */
     public function min()
     {
-        return $this->applyOrNull('min');
+        if ($this->isEmpty()) {
+            throw new UnderflowException(
+                'Can not get a minimum value on an empty collection.'
+            );
+        }
+
+        return min($this->_elements);
     }
 
     /**
@@ -244,7 +252,13 @@ class ArrayCollection extends ArrayEnumerable implements Collection
      */
     public function max()
     {
-        return $this->applyOrNull('max');
+        if ($this->isEmpty()) {
+            throw new UnderflowException(
+                'Can not get a maximum value on an empty collection.'
+            );
+        }
+
+        return max($this->_elements);
     }
 
     /**
@@ -252,7 +266,7 @@ class ArrayCollection extends ArrayEnumerable implements Collection
      */
     public function sum()
     {
-        return $this->applyOrNull('array_sum');
+        return $this->isEmpty() ? 0 : array_sum($this->_elements);
     }
 
     /**
@@ -260,15 +274,7 @@ class ArrayCollection extends ArrayEnumerable implements Collection
      */
     public function product()
     {
-        return $this->applyOrNull('array_product');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    private function applyOrNull($callback)
-    {
-        return !empty($this->_elements) ? $callback($this->_elements) : null;
+        return $this->isEmpty() ? 1 : array_product($this->_elements);
     }
 
     /**

--- a/library/Xi/Collections/Enumerable/ArrayEnumerable.php
+++ b/library/Xi/Collections/Enumerable/ArrayEnumerable.php
@@ -13,36 +13,36 @@ class ArrayEnumerable implements Enumerable
     /**
      * @var array
      */
-    protected $_elements;
+    protected $elements;
 
     /**
      * @param array $elements
      */
     public function __construct($elements)
     {
-        $this->_elements = $elements;
+        $this->elements = $elements;
     }
 
     public function getIterator()
     {
-        return new \ArrayIterator($this->_elements);
+        return new \ArrayIterator($this->elements);
     }
 
     public function toArray()
     {
-        return $this->_elements;
+        return $this->elements;
     }
 
     public function each($callback, $userdata = null)
     {
-        array_walk($this->_elements, $callback, $userdata);
+        array_walk($this->elements, $callback, $userdata);
         return $this;
     }
 
     public function reduce($callback, $initial = null)
     {
         $result = $initial;
-        foreach ($this->_elements as $key => $value) {
+        foreach ($this->elements as $key => $value) {
             $result = $callback($result, $value, $key);
         }
         return $result;
@@ -56,7 +56,7 @@ class ArrayEnumerable implements Enumerable
 
     public function exists($callback)
     {
-        foreach ($this->_elements as $value) {
+        foreach ($this->elements as $value) {
             if ($callback($value)) {
                 return true;
             }
@@ -66,7 +66,7 @@ class ArrayEnumerable implements Enumerable
 
     public function forAll($callback)
     {
-        foreach ($this->_elements as $value) {
+        foreach ($this->elements as $value) {
             if (!$callback($value)) {
                 return false;
             }
@@ -76,7 +76,7 @@ class ArrayEnumerable implements Enumerable
 
     public function find($callback)
     {
-        foreach ($this->_elements as $value) {
+        foreach ($this->elements as $value) {
             if ($callback($value)) {
                 return $value;
             }
@@ -86,12 +86,12 @@ class ArrayEnumerable implements Enumerable
 
     public function first()
     {
-        return reset($this->_elements);
+        return reset($this->elements);
     }
 
     public function last()
     {
-        return end($this->_elements);
+        return end($this->elements);
     }
 
     public function countAll($predicate)
@@ -107,6 +107,6 @@ class ArrayEnumerable implements Enumerable
 
     public function count()
     {
-        return count($this->_elements);
+        return count($this->elements);
     }
 }

--- a/tests/Xi/Collections/Collection/AbstractCollectionTest.php
+++ b/tests/Xi/Collections/Collection/AbstractCollectionTest.php
@@ -641,10 +641,24 @@ abstract class AbstractCollectionTest extends AbstractEnumerableTest
     public function minimumProvider()
     {
         return array(
-            array(array(), null),
             array(array(1, 2, 3), 1),
             array(array(5, 2), 2),
         );
+    }
+
+    /**
+     * @test
+     */
+    public function minimumOfValuesOnAnEmptyCollectionShouldThrowAnException()
+    {
+        $collection = $this->getCollection();
+
+        $this->setExpectedException(
+            'UnderflowException',
+            'Can not get a minimum value on an empty collection.'
+        );
+
+        $collection->min();
     }
 
     /**
@@ -664,10 +678,24 @@ abstract class AbstractCollectionTest extends AbstractEnumerableTest
     public function maximumProvider()
     {
         return array(
-            array(array(), null),
             array(array(1, 2, 3), 3),
             array(array(5, 2), 5),
         );
+    }
+
+    /**
+     * @test
+     */
+    public function maximumOfValuesOnAnEmptyCollectionShouldThrowAnException()
+    {
+        $collection = $this->getCollection();
+
+        $this->setExpectedException(
+            'UnderflowException',
+            'Can not get a maximum value on an empty collection.'
+        );
+
+        $collection->max();
     }
 
     /**
@@ -687,7 +715,7 @@ abstract class AbstractCollectionTest extends AbstractEnumerableTest
     public function sumProvider()
     {
         return array(
-            array(array(), null),
+            array(array(), 0),
             array(array(0), 0),
             array(array(1, 2), 3),
             array(array(2, 4, 6), 12),
@@ -711,7 +739,7 @@ abstract class AbstractCollectionTest extends AbstractEnumerableTest
     public function productProvider()
     {
         return array(
-            array(array(), null),
+            array(array(), 1),
             array(array(0), 0),
             array(array(1, 2), 2),
             array(array(2, 3, 5), 30),


### PR DESCRIPTION
- Removed null return values from aggregation methods
- Removed old school underscore prefix from `$_elements`
